### PR TITLE
Install Template Toolkit

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -34,6 +34,23 @@ test -z ${build} && exit
 cache=$(cd "$2/" && pwd)
 test -z ${cache} && exit
 
+
+# install Template Toolkit
+toolkit_file_name="Template-Toolkit-2.26.tar.gz"
+TOOLKIT_URL="http://www.cpan.org/modules/by-module/Template/${toolkit_file_name}"
+
+echo "-----> Download $toolkit_file_name"
+
+cd ${cache}
+curl -sO ${TOOLKIT_URL}
+echo "Download $toolkit_file_name done"
+tar zxf $toolkit_file_name
+cd Template-Toolkit-2.26
+perl Makefile.PL TT_ACCEPT=y
+make
+make install
+echo "-----> Template Toolkit install done"
+
 # Start getting erlang
 
 DEFAULT_OTP_VERSION="master"
@@ -125,6 +142,7 @@ make install 2>&1 | indent
 
 
 echo "-----> Tsung installed"
+
 
 cp /app/otp/bin/erl /app/bin/erl
 

--- a/bin/compile
+++ b/bin/compile
@@ -34,26 +34,25 @@ test -z ${build} && exit
 cache=$(cd "$2/" && pwd)
 test -z ${cache} && exit
 
-
 # install Template Toolkit
-toolkit_file_name="Template-Toolkit-2.26.tar.gz"
-TOOLKIT_URL="http://www.cpan.org/modules/by-module/Template/${toolkit_file_name}"
+toolkit_file_name="Template-Toolkit-2.26"
+TOOLKIT_URL="http://www.cpan.org/modules/by-module/Template/${toolkit_file_name}.tar.gz"
 
 echo "-----> Download $toolkit_file_name"
 
 cd ${cache}
 curl -sO ${TOOLKIT_URL}
 echo "Download $toolkit_file_name done"
-tar zxf $toolkit_file_name
-cd Template-Toolkit-2.26
+tar zxf "${toolkit_file_name}.tar.gz"
+cd $toolkit_file_name
 
 perl Makefile.PL TT_ACCEPT=y PREFIX=${build}
 make
 make install
+
 echo "-----> Template Toolkit install done"
 
 # Start getting erlang
-
 DEFAULT_OTP_VERSION="master"
 if [ -f ${build}/.preferred_otp_version ]; then
     OTP_VERSION=$(cat ${build}/.preferred_otp_version)
@@ -143,7 +142,6 @@ make install 2>&1 | indent
 
 
 echo "-----> Tsung installed"
-
 
 cp /app/otp/bin/erl /app/bin/erl
 

--- a/bin/compile
+++ b/bin/compile
@@ -46,7 +46,8 @@ curl -sO ${TOOLKIT_URL}
 echo "Download $toolkit_file_name done"
 tar zxf $toolkit_file_name
 cd Template-Toolkit-2.26
-perl Makefile.PL TT_ACCEPT=y
+
+perl Makefile.PL TT_ACCEPT=y PREFIX=${build}
 make
 make install
 echo "-----> Template Toolkit install done"


### PR DESCRIPTION
Tsung depends on [template-toolkit.org](http://template-toolkit.org/) to create HTML for its Web UI.

This PR adds installing template-toolkit.org part of the tsung build.

http://tsung.erlang-projects.org/user_manual/installation.html#dependencies